### PR TITLE
Added localised date formatting

### DIFF
--- a/components/Date/Date.vue
+++ b/components/Date/Date.vue
@@ -1,12 +1,15 @@
 <script setup>
 import * as prismicH from "@prismicio/helpers";
 
-import { format } from "date-fns";
+import { DateTime } from "luxon";
+
+const nuxtApp = useNuxtApp();
+const locale = nuxtApp.$i18n.locale.value;
 
 defineProps(["postDate"]);
 </script>
 <template>
   <time :dateTime="prismicH.asDate(postDate)">
-    {{ format(prismicH.asDate(postDate), "dd/MM/yyyy") }}</time
+    {{ DateTime.fromISO(postDate).setLocale(locale).toLocaleString() }}</time
   >
 </template>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "dependencies": {
         "@prismicio/client": "^7.0.1",
         "@prismicio/helpers": "^2.3.9",
-        "date-fns": "^2.30.0",
         "flag-icons": "^6.7.0",
+        "luxon": "^3.4.4",
         "piglatin": "^0.1.2",
         "prettier": "^2.8.8",
         "primevue": "^3.29.2",
@@ -513,17 +513,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/runtime": {
-      "version": "7.23.8",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.8.tgz",
-      "integrity": "sha512-Y7KbAP984rn1VGMbGqKmBLio9V7y5Je9GvU4rQPCPinCyNfUcToxIXl06d59URp/F3LwinvODxab5N/G6qggkw==",
-      "dependencies": {
-        "regenerator-runtime": "^0.14.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/standalone": {
@@ -4787,21 +4776,6 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
     },
-    "node_modules/date-fns": {
-      "version": "2.30.0",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
-      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
-      "dependencies": {
-        "@babel/runtime": "^7.21.0"
-      },
-      "engines": {
-        "node": ">=0.11"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/date-fns"
-      }
-    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -7078,6 +7052,14 @@
       "dev": true,
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/luxon": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+      "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/magic-string": {
@@ -10361,11 +10343,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/regenerator-runtime": {
-      "version": "0.14.1",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
-      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/require-directory": {
       "version": "2.1.1",

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
   "dependencies": {
     "@prismicio/client": "^7.0.1",
     "@prismicio/helpers": "^2.3.9",
-    "date-fns": "^2.30.0",
     "flag-icons": "^6.7.0",
+    "luxon": "^3.4.4",
     "piglatin": "^0.1.2",
     "prettier": "^2.8.8",
     "primevue": "^3.29.2",


### PR DESCRIPTION
## Action
- Switched from `date-fns` to Luxon to add localised date formatting. 

## Reason
`date-fns` requires importing each locale but Luxon provides locales with the package so it is easier to dynamically import locales rather than manually specifying them so the `Date` component will be automatically compatible with any new Prismic locales.